### PR TITLE
Expose clickable image’s alt and destination to ImageProvider

### DIFF
--- a/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/AssetImageProvider.swift
@@ -28,7 +28,7 @@ public struct AssetImageProvider: ImageProvider {
     self.bundle = bundle
   }
 
-  public func makeImage(url: URL?) -> some View {
+  public func makeImage(url: URL?, alt: String? = nil, destination: String? = nil) -> some View {
     if let url = url, let image = self.image(url: url) {
       ResizeToFit(idealSize: image.size) {
         Image(platformImage: image)

--- a/Sources/MarkdownUI/Extensibility/DefaultImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/DefaultImageProvider.swift
@@ -10,7 +10,7 @@ public struct DefaultImageProvider: ImageProvider {
     self.urlSession = urlSession
   }
 
-  public func makeImage(url: URL?) -> some View {
+  public func makeImage(url: URL?, alt: String? = nil, destination: String? = nil) -> some View {
     DefaultImageView(url: url, urlSession: self.urlSession)
   }
 }

--- a/Sources/MarkdownUI/Extensibility/ImageProvider.swift
+++ b/Sources/MarkdownUI/Extensibility/ImageProvider.swift
@@ -23,19 +23,19 @@ public protocol ImageProvider {
   /// will call this method for each image in their contents.
   ///
   /// - Parameter url: The URL of the image to display.
-  @ViewBuilder func makeImage(url: URL?) -> Body
+  @ViewBuilder func makeImage(url: URL?, alt: String?, destination: String?) -> Body
 }
 
 struct AnyImageProvider: ImageProvider {
-  private let _makeImage: (URL?) -> AnyView
+  private let _makeImage: (URL?, String?, String?) -> AnyView
 
   init<I: ImageProvider>(_ imageProvider: I) {
     self._makeImage = {
-      AnyView(imageProvider.makeImage(url: $0))
+      AnyView(imageProvider.makeImage(url: $0, alt: $1, destination: $2))
     }
   }
 
-  func makeImage(url: URL?) -> some View {
-    self._makeImage(url)
+  func makeImage(url: URL?, alt: String? = nil, destination: String? = nil) -> some View {
+    self._makeImage(url, alt, destination)
   }
 }

--- a/Sources/MarkdownUI/Views/Inlines/ImageView.swift
+++ b/Sources/MarkdownUI/Views/Inlines/ImageView.swift
@@ -21,7 +21,7 @@ struct ImageView: View {
   }
 
   private var label: some View {
-    self.imageProvider.makeImage(url: self.url)
+    self.imageProvider.makeImage(url: self.url, alt: self.data.alt, destination: self.data.destination)
       .link(destination: self.data.destination)
       .accessibilityLabel(self.data.alt)
   }


### PR DESCRIPTION
Adding `alt` and `destination` to the `ImageProvider` protocol's `makeImage` function and modifying necessary code so it still compiles.